### PR TITLE
Declare module for React example

### DIFF
--- a/examples/hello-world-typescript/types/static.d.ts
+++ b/examples/hello-world-typescript/types/static.d.ts
@@ -1,6 +1,10 @@
 /* Use this file to declare any custom file extensions for importing */
 /* Use this folder to also add/extend a package d.ts file, if needed. */
 
+declare module "electron-snowpack" {
+  const getAssetURL: (asset: string) => string;
+}
+
 /* CSS MODULES */
 declare module '*.module.css' {
   const classes: { [key: string]: string };


### PR DESCRIPTION
I noticed there are no types for the package, so I made a quick fix for my own project. I think a better solution would be proper types (maybe even convert it into TypeScript) but this PR should at least do so the React example has no type errors.